### PR TITLE
Create getComponents(type)

### DIFF
--- a/src/main/java/com/github/mathlon26/ribble/ecs/EntityManager.java
+++ b/src/main/java/com/github/mathlon26/ribble/ecs/EntityManager.java
@@ -138,6 +138,7 @@ public class EntityManager {
 
         if (pool == null) {
             ExceptionHandler.raise(IllegalArgumentException.class, "No Component pool of type: " + type.getName());
+            return null;
         }
         return pool.getComponents();
     }

--- a/src/main/java/com/github/mathlon26/ribble/ecs/EntityManager.java
+++ b/src/main/java/com/github/mathlon26/ribble/ecs/EntityManager.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Collection;
 
 /**
  * Simple EntityManager façade for creating entities and retrieving components.
@@ -108,6 +109,13 @@ public class EntityManager {
     public static <T extends Component> T getComponent(Entity entity, Class<T> type) {
         return getInstance().getComponentFor(entity, type);
     }
+
+    public static <T extends Component> Collection<T> getComponents(Class<T> type)
+    {
+        return getInstance().getComponentsInst(type);
+    }
+
+
     public static <T extends Component> void addComponent(Entity entity, T component)
     {
         getInstance().addComponentTo(entity, component);
@@ -123,6 +131,17 @@ public class EntityManager {
         if(pool == null){return null;}
         return pool.getComponent(entity);
     }
+    // Instance version of getComponents
+    public <T extends Component> Collection<T> getComponentsInst(Class<T> type)
+    {
+        ComponentPool<T> pool = componentPools.getPool(type);
+
+        if (pool == null) {
+            ExceptionHandler.raise(IllegalArgumentException.class, "No Component pool of type: " + type.getName());
+        }
+        return pool.getComponents();
+    }
+
     @SuppressWarnings("unchecked")
     public <T extends Component> void addComponentTo(Entity entity, T component)
     {

--- a/src/main/java/com/github/mathlon26/ribble/ecs/component/ComponentPool.java
+++ b/src/main/java/com/github/mathlon26/ribble/ecs/component/ComponentPool.java
@@ -6,6 +6,7 @@ import com.github.mathlon26.ribble.io.output.sys.ExceptionHandler;
 
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 
 public class ComponentPool<T extends Component> {
@@ -13,7 +14,13 @@ public class ComponentPool<T extends Component> {
 
     }
 
-    private HashMap<Entity, T> components = new HashMap<Entity, T>();
+    private final HashMap<Entity, T> components = new HashMap<Entity, T>();
+
+    public Collection<T> getComponents()
+    {
+        return components.values();
+    }
+
 
 
     public void addComponent(Entity entity, T component)

--- a/src/test/java/ecs/component/ComponentPoolTest.java
+++ b/src/test/java/ecs/component/ComponentPoolTest.java
@@ -1,5 +1,6 @@
 package ecs.component;
 
+import com.github.mathlon26.ribble.ecs.EntityManager;
 import com.github.mathlon26.ribble.ecs.component.ComponentPool;
 import com.github.mathlon26.ribble.ecs.component.RenderComponent;
 import com.github.mathlon26.ribble.ecs.component.TransformComponent;
@@ -7,8 +8,10 @@ import com.github.mathlon26.ribble.ecs.entity.Entity;
 import com.github.mathlon26.ribble.math.Transform;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ComponentPoolTest {
 
@@ -35,6 +38,44 @@ public class ComponentPoolTest {
         assertNotEquals(null, transformPool.getComponent(entity1));
         assertNotEquals(transform1, transformPool.getComponent(entity2));
     }
+
+    @Test
+    void testGetComponentsStandalone()
+    {
+        ComponentPool<TransformComponent> pool = new ComponentPool<>();
+
+        Entity entity = new Entity(0);
+        TransformComponent trans = new TransformComponent(new Transform());
+
+        pool.addComponent(entity, trans);
+
+        List<TransformComponent> expected = List.of(trans);
+
+        Collection<TransformComponent> components = pool.getComponents();
+
+        assertTrue(components.containsAll(expected));
+        assertTrue(expected.containsAll(components));
+        assertNotEquals(null, components);
+    }
+
+    @Test
+    void testGetComponents()
+    {
+        EntityManager man = new EntityManager();
+        Entity entity = man.createEntityInstance();
+        TransformComponent trans = new TransformComponent(new Transform());
+        man.addComponentTo(entity, trans);
+
+        List<TransformComponent> expected = List.of(trans);
+        Collection<TransformComponent> components = man.getComponentsInst(TransformComponent.class);
+
+        assertTrue(components.containsAll(expected));
+        assertTrue(expected.containsAll(components));
+        assertNotEquals(null, components);
+
+    }
+
+
 
 
 


### PR DESCRIPTION
# Goal
Give users the ability to get a list of all components of the same type (mainly for use in systems)

# What changed
* Created a function getComponents in ComponentPool and EntityManager that returns a collection of components of a specific type
* Created tests for getComponents

# Notes
All tests pass

# Improvements for later
* Tests currently don't use TestComponent